### PR TITLE
[alex] [andrew] [tim] Client routes fix.

### DIFF
--- a/src/client/init.jsx
+++ b/src/client/init.jsx
@@ -14,10 +14,13 @@ const router = Router.create({
     location: Router.HistoryLocation
 });
 
-RouteUtils.run(router).then(async ({Handler, state}) => {
-    await RouteUtils.init(state.routes, {state, flux});
-
-    React.withContext({flux}, () => {
-        React.render(<Handler {...state} />, document.getElementById('app'));
+router.run((Handler, state) => {
+    RouteUtils.init(state.routes, {state, flux}).then(() => {
+        const appRoot = (
+            <FluxComponent flux={flux}>
+                <Handler {...state} />
+            </FluxComponent>
+        );
+        React.render(appRoot, document.getElementById('app'));
     });
-}).catch(err => console.error(err));
+});

--- a/src/server/routes.jsx
+++ b/src/server/routes.jsx
@@ -8,7 +8,7 @@ import RouteUtils from '../shared/utils/RouteUtils';
 
 import App from '../shared/App';
 import Flux from '../shared/Flux';
-import AppRoutes from '../shared/routes.js';
+import AppRoutes from '../shared/Routes';
 import TrailRoutes from './routes/trail-routes';
 import TagRoutes from './routes/tag-routes';
 import AuthRoutes from './routes/auth-routes';
@@ -36,36 +36,27 @@ routes.get('*', (req, res) => {
     const router = Router.create({
         routes: AppRoutes,
         location: req.url,
-        onError: error => {
-            throw error;
-        }
+        onError: err => process.stderr.write(err.stack + '\n')
     });
     const flux = new Flux();
 
     // Process current route.
     // state.routes contains the current route and its parent.
     // Handler is the React component that handlers the current route.
-    RouteUtils.run(router).then(({Handler, state}) => {
+    router.run((Handler, state) => {
         // Run init method of current route and its parents.
         RouteUtils.init(state.routes, {state, flux}).then(() => {
-            React.withContext({flux}, () => {
-                const rendered = React.renderToString(<Handler {...state} />);
-                res.send(`
-                    <html>
-                        <head>
-                            <link rel="stylesheet" type="text/css" href="/css/main.css" />
-                        </head>
-                        <body>
-                            <div id="app">
-                                ${rendered}
-                            </div>
-                            <script type="text/javascript" src="/js/bundle.js"></script>
-                        </body>
-                    </html>
-                `);
-            });
+            // Since no asynchronous data is being fetched (data should be fetched in init
+            // function of routes), we can safely renderToString.
+            const rendered = React.renderToString(
+                <FluxComponent flux={flux}>
+                    <Handler {...state} />
+                </FluxComponent>
+            );
+            // TODO: put into seperate file.
+            res.send(`<html><head><link rel="stylesheet" type="text/css" href="/css/main.css" /></head><body><div id="app">${rendered}</div><script type="text/javascript" src="/js/bundle.js"></script></body></html>`);
         }).catch(err => { process.stderr.write(err.stack + '\n'); });
-    }).catch(err => { process.stderr.write(err.stack + '\n'); });
+    });
 });
 
 export default routes;

--- a/src/shared/App.jsx
+++ b/src/shared/App.jsx
@@ -3,11 +3,7 @@ import { RouteHandler } from 'react-router';
 
 export default React.createClass({
     render: function(){
-        return (
-            <div>
-                <RouteHandler />
-            </div>
-        );
+        return <RouteHandler {...this.props} key={this.props.pathname} />;
     }
 });
 

--- a/src/shared/Routes.jsx
+++ b/src/shared/Routes.jsx
@@ -3,12 +3,14 @@ import { Route, DefaultRoute } from 'react-router';
 
 import App from './App';
 import Home from './components/Home';
+import Test from './components/Test';
 import Trail from './components/Trail';
 import AddTrail from './components/AddTrail';
 
 export default (
-    <Route name="home" path="/">
+    <Route handler={App} path="/">
         <DefaultRoute handler={Home} />
+        <Route name="test" path="test" handler={Test} />
         <Route name="addTrail" path="trail/add" handler={AddTrail} />
         <Route name="trail" path="trail/:trailId" handler={Trail} />
     </Route>

--- a/src/shared/components/Test.jsx
+++ b/src/shared/components/Test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default React.createClass({
+    render: function(){
+        return (
+            <div className="test">
+                OMG THIS WORKED
+            </div>
+        );
+    }
+});

--- a/src/shared/components/TrailCard.jsx
+++ b/src/shared/components/TrailCard.jsx
@@ -11,7 +11,7 @@ export default React.createClass({
     },
 
     clickCard: function(trailId){
-        window.location.replace(`http://localhost:8000/trail/${trailId}`);
+        this.transitionTo('test', {trailId});
     },
 
     render: function(){

--- a/src/shared/utils/RouteUtils.js
+++ b/src/shared/utils/RouteUtils.js
@@ -6,13 +6,5 @@ export default {
             .filter(method => typeof method === 'function')
             .map(method => method(params))
         ).catch(err => console.error(err.stack));
-    },
-    // Wraps the router.run function in a promise.
-    run: async router => {
-        return new Promise((resolve, reject) => {
-            router.run((Handler, state) => {
-                resolve({Handler, state});
-            });
-        });
     }
 };

--- a/tasks/client.js
+++ b/tasks/client.js
@@ -31,7 +31,7 @@ var webpackConfig = {
 var compile = function(){
     return gulp.src('./src/client/init.jsx')
         .pipe(webpack(webpackConfig))
-        .pipe(gulp.dest(path.resolve(__dirname, '../dist/client/js/')));
+        .pipe(gulp.dest(path.resolve(__dirname, '../dist/client/static/js/')));
 };
 
 var watch = function(done){
@@ -45,7 +45,7 @@ var watch = function(done){
 
     gulp.src('./src/client/init.jsx')
         .pipe(webpack(assign({watch: true, onCompile: onCompile}, webpackConfig)))
-        .pipe(gulp.dest(path.resolve(__dirname, '../dist/client/js/')));
+        .pipe(gulp.dest(path.resolve(__dirname, '../dist/client/static/js/')));
 };
 
 gulp.task('compile:client', compile);


### PR DESCRIPTION
Issue was that the router.run function was being wrapped in a promise but the callback for router.run
is expected to be called multiple times on the client (on each route change). Promise resolve functions
should only be called once. Now calling router.run directly.

Also removed React.withContext since its deprecated. Now passing in flux instance using FluxComponent (see http://acdlite.github.io/flummox/docs/guides/react-integration).

Right now trail cards all point to a test page. Will remove later.
